### PR TITLE
allows use of tikzcd inside tikzpicture as scope

### DIFF
--- a/tikzlibrarycd.code.tex
+++ b/tikzlibrarycd.code.tex
@@ -11,7 +11,7 @@
 % but WITHOUT ANY WARRANTY; without even the implied warranty of
 % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 % GNU General Public License for more details.
-% 
+%
 % You should have received a copy of the GNU General Public License
 % along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -22,6 +22,7 @@
 \def\tikzcdset{\pgfqkeys{/tikz/commutative diagrams}}
 
 \tikzcdset{
+  name/.style={/tikz/every matrix/.append style={name=#1}},
   arrows/.code={\tikzcdset{every arrow/.append style={#1}}},
   labels/.code={\tikzcdset{every label/.append style={#1}}},
   cells/.code={\tikzcdset{every cell/.append style={#1}}},
@@ -85,7 +86,7 @@
     }{%
       \def#1{\tikzcdmatrixname-#2}%
     }}
-    
+
 % The unknown key handler and direction argument parser
 \tikzcdset{
   .unknown/.code={%
@@ -124,7 +125,12 @@
 \def\tikzcd@@{\pgfutil@ifnextchar[{\tikzcd@handle@shortcuts@next\tikzcd@}{\tikzcd@[]}}
 
 \def\tikzcd@[#1]{%
-  \tikzpicture[/tikz/commutative diagrams/.cd,every diagram,#1]%
+  \tikzifinpicture{%
+    \let\tikzcdpicture\scope\let\endtikzcdpicture\endscope% <-- inside tikzpicture : start a scope
+  }{%
+    \let\tikzcdpicture\tikzpicture\let\endtikzcdpicture\endtikzpicture% <-- outside tikzpicture : start a tikzpicture
+  }%
+  \tikzcdpicture[/tikz/commutative diagrams/.cd,every diagram,#1]%
   \ifx\arrow\tikzcd@arrow%
     \pgfutil@packageerror{tikz-cd}{Diagrams cannot be nested}{}%
   \fi%
@@ -162,7 +168,7 @@
     \tikzcd@before@paths@hook%
     \tikzcd@savedpaths%
   \endgroup%
-  \endtikzpicture%
+  \endtikzcdpicture%
   \ifnum0=`{}\fi}
 
 % The arrow commands


### PR DESCRIPTION
Following the idea of [this answer](https://tex.stackexchange.com/a/425839) and to make the interaction with `tikz` more fluent in some cases like [this one](https://tex.stackexchange.com/q/405149/9335), I modified the code to use `tikzpicture` or `scope` depending from where we call the `tikzcd` environment. I also added a style `name` to facilitate the access to the cells.

Here is a demonstration how it works:

```
\documentclass[tikz,border=7pt]{standalone}
\usetikzlibrary{cd}

\begin{document}
  \begin{tikzpicture}
    \fill[blue!14] circle(2);
    \begin{tikzcd}[name=A]
      K \arrow{r}{a} \arrow{d}{b} & B \arrow{d}{c} \\
      C \arrow{r}{d} & D
    \end{tikzcd}
    \draw[red,-latex] (A-1-1) to[bend right] (-1,-1) node[below]{Test};
  \end{tikzpicture}
\end{document}
```
![tikzcd inside tikzpicture](https://i.imgur.com/V1xA10O.png)