### PR TITLE
Provide \to and \mapsto as shortcuts

### DIFF
--- a/tikzlibrarycd.code.tex
+++ b/tikzlibrarycd.code.tex
@@ -130,6 +130,13 @@
   \fi%
   \let\arrow\tikzcd@arrow%
   \let\ar\tikzcd@arrow%
+  
+  % Overwrite to / mapsto
+  \global\let\oldto\to%
+	\global\let\oldmapsto\mapsto%
+  \def\to{\arrow}%
+  \def\mapsto{\arrow[mapsto]}%
+  
   \def\rar{\tikzcd@xar{r}}%
   \def\lar{\tikzcd@xar{l}}%
   \def\dar{\tikzcd@xar{d}}%
@@ -162,6 +169,11 @@
     \tikzcd@before@paths@hook%
     \tikzcd@savedpaths%
   \endgroup%
+  
+  % Reset to and mapsto
+  \gdef\to{\oldto}%
+	\gdef\mapsto{\oldmapsto}%
+    
   \endtikzpicture%
   \ifnum0=`{}\fi}
 


### PR DESCRIPTION
This PR enables `\to` and `\mapsto` as shortcuts for the common latex arrows. Thus, the following works
```latex
\begin{tikzcd}
	E \to[r, "L"] & F
	\\
	e \mapsto{r} & L(e).
\end{tikzcd}
```
Advantages: 
- Consistent with normal equations where `\to` and `\mapsto` are used for the arrows
- Semantic naming 

I've marked this as a draft PR, as the following points still need to be done but I wanted to get early feedback:
- [ ] Document these commands
- [ ] Support the new syntax for `\mapsto` i.e. `\mapsto[r]` instead of `\mapsto{r}`. Any advice on how to do this?